### PR TITLE
feat: CLI 실행시 --contentsDir 인자 받을 수 있도록 개선 (#2)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,18 +16,18 @@ const DATE_FORMAT = 'yyyy-MM-dd HH:MM:SS'
 const ignoreFunc = (file, stats) =>
   stats.isDirectory() && path.basename(file) == IGNORE_DIR
 
-const addSlashToDirPath = (contentDir) =>
-  contentDir.startsWith('/') ? contentDir : `/${contentDir}`
+const addSlashToDirPath = (contentsDir) =>
+  contentsDir.startsWith('/') ? contentsDir : `/${contentsDir}`
 
-const getContentDir = () => {
-  const contentDirArgIndex = process.argv.indexOf('--contentDir');
-  if (contentDirArgIndex === -1 || contentDirArgIndex + 1 >= process.argv.length) {
+const getContentsDir = () => {
+  const contentsDirArgIndex = process.argv.indexOf('--contentsDir');
+  if (contentsDirArgIndex === -1 || contentsDirArgIndex + 1 >= process.argv.length) {
     return DEFAULT_CONTENTS_DIR;
   }
-  return addSlashToDirPath(process.argv[contentDirArgIndex + 1]);
+  return addSlashToDirPath(process.argv[contentsDirArgIndex + 1]);
 }
 
-const getTargetDir = (contentDir) => cwd + contentDir;
+const getTargetDir = (contentsDir) => cwd + contentsDir;
 
 const getCategories = async (targetDir) => {
   const markdownFiles = await rr(targetDir, [ignoreFunc])
@@ -133,11 +133,11 @@ const fetchTitle = async (targetDir, category) => {
 
 module.exports = (async function() {
   const date = dateFns.format(new Date(), DATE_FORMAT)
-  const contentDir = getContentDir();
-  const targetDir = getTargetDir(contentDir);
+  const contentsDir = getContentsDir();
+  const targetDir = getTargetDir(contentsDir);
 
   log.info('📅 Create new post:', date)
-  log.info('🗂 Content directory:', contentDir)
+  log.info('🗂 Content directory:', contentsDir)
   log.start('🚚 Start to process!\n')
 
   const category = await fetchCategory(targetDir)

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,8 +8,7 @@ const inquirer = require('inquirer')
 const log = require('signale')
 const cwd = process.cwd()
 
-const CONTENTS_DIR = '/content/blog'
-const TARGET_DIR = `${cwd}${CONTENTS_DIR}`
+const DEFAULT_CONTENTS_DIR = '/content/blog'
 const IGNORE_DIR = 'images'
 const UTF_8 = 'utf8'
 const DATE_FORMAT = 'yyyy-MM-dd HH:MM:SS'
@@ -17,8 +16,21 @@ const DATE_FORMAT = 'yyyy-MM-dd HH:MM:SS'
 const ignoreFunc = (file, stats) =>
   stats.isDirectory() && path.basename(file) == IGNORE_DIR
 
-const getCategories = async () => {
-  const markdownFiles = await rr(TARGET_DIR, [ignoreFunc])
+const addSlashToDirPath = (contentDir) =>
+  contentDir.startsWith('/') ? contentDir : `/${contentDir}`
+
+const getContentDir = () => {
+  const contentDirArgIndex = process.argv.indexOf('--contentDir');
+  if (contentDirArgIndex === -1 || contentDirArgIndex + 1 >= process.argv.length) {
+    return DEFAULT_CONTENTS_DIR;
+  }
+  return addSlashToDirPath(process.argv[contentDirArgIndex + 1]);
+}
+
+const getTargetDir = (contentDir) => cwd + contentDir;
+
+const getCategories = async (targetDir) => {
+  const markdownFiles = await rr(targetDir, [ignoreFunc])
 
   return _.uniq(
     markdownFiles
@@ -41,10 +53,10 @@ const refineContents = rawContents =>
     .split("'")
     .join('')
 
-const fetchCategory = async () => {
+const fetchCategory = async (targetDir) => {
   let category
   const customCategoryOption = '[ CREATE NEW CATEGORY ]'
-  const categories = await getCategories()
+  const categories = await getCategories(targetDir)
   const categoryChoices = [
     ...categories,
     new inquirer.Separator(),
@@ -91,7 +103,7 @@ const fetchCategory = async () => {
   return category
 }
 
-const fetchTitle = async category => {
+const fetchTitle = async (targetDir, category) => {
   const { title } = await inquirer.prompt([
     {
       type: 'input',
@@ -104,7 +116,7 @@ const fetchTitle = async category => {
         }
 
         const fileName = getFileName(val)
-        const dest = `${TARGET_DIR}/${category}/${fileName}.md`
+        const dest = `${targetDir}/${category}/${fileName}.md`
         const destFileExists = await fs.pathExists(dest)
 
         if (destFileExists) {
@@ -121,19 +133,22 @@ const fetchTitle = async category => {
 
 module.exports = (async function() {
   const date = dateFns.format(new Date(), DATE_FORMAT)
+  const contentDir = getContentDir();
+  const targetDir = getTargetDir(contentDir);
 
   log.info('📅 Create new post:', date)
+  log.info('🗂 Content directory:', contentDir)
   log.start('🚚 Start to process!\n')
 
-  const category = await fetchCategory()
-  const destDir = `${TARGET_DIR}/${category}`
+  const category = await fetchCategory(targetDir)
+  const destDir = `${targetDir}/${category}`
   const destDirExists = await fs.pathExists(destDir)
 
   if (!destDirExists) {
     await fs.ensureDir(destDir)
   }
 
-  const title = await fetchTitle(category)
+  const title = await fetchTitle(category, targetDir)
   const fileName = getFileName(title)
   const contents = refineContents({
     title,

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,7 +148,7 @@ module.exports = (async function() {
     await fs.ensureDir(destDir)
   }
 
-  const title = await fetchTitle(category, targetDir)
+  const title = await fetchTitle(targetDir, category)
   const fileName = getFileName(title)
   const contents = refineContents({
     title,


### PR DESCRIPTION
#2 번 이슈에서 `CONTENTS_DIR` 경로를 CLI에서 `--contentsDir` 인자로 받을 수 있도록 개선했습니다.

- `--contentsDir`만 있을 경우 -> `'/content/blog'`
- `--contentsDir`이 없을 경우 -> `'/content/blog'`
- `--contentsDir`이 있고 `'/content/blog'`을 다음 인자로 받은 경우 -> `'/content/blog'`
- `--contentsDir`이 있고 `'content/blog'`을 다음 인자로 받은 경우 -> `'/content/blog'`

`gatsby-post-gen` 을 사용하려 했는데 `/content/blog` 경로만 되는 것 같아 추가해보았습니다.
기존 코드를 최대한 변경하지 않는 선에서 작업 진행했습니다!
확인 부탁드리겠습니다.🙂  감사합니다.